### PR TITLE
Provide option to limit total number of files considered for manifest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                             string(credentialsId: 'aws_kg_hub_secret_key', variable: 'AWS_SECRET_ACCESS_KEY')]) {
                             script {
                                 def run_make_manifest = sh(
-                                    script: '. venv/bin/activate && cd utils/ && python make_kg_manifest.py --bucket kg-hub-public-data --outpath MANIFEST.yaml', returnStatus: true
+                                    script: '. venv/bin/activate && cd utils/ && python make_kg_manifest.py --bucket kg-hub-public-data --outpath MANIFEST.yaml --maximum 10', returnStatus: true
                                 )
                                 if (run_make_manifest == 0) {
                                     if (env.BRANCH_NAME != 'main') { // upload raw to s3 if we're on correct branch

--- a/utils/make_kg_manifest.py
+++ b/utils/make_kg_manifest.py
@@ -110,7 +110,7 @@ def run(bucket: str, outpath: str, maximum = None):
             previous_manifest = load_previous_manifest(bucket, manifest_name)
         else:
             previous_manifest = []
-        graph_file_keys = get_graph_file_keys(keys, previous_manifest)
+        graph_file_keys = get_graph_file_keys(keys, maximum, previous_manifest)
         project_contents = validate_projects(bucket, keys, graph_file_keys)
         dataset_objects = create_dataset_objects(graph_file_keys, 
                                                 project_metadata,
@@ -380,7 +380,7 @@ def validate_projects(bucket: str, keys: list, graph_file_keys: dict) -> None:
         
     return project_contents
 
-def get_graph_file_keys(keys: list, previous_manifest = [], maximum = None):
+def get_graph_file_keys(keys: list, maximum: int, previous_manifest = []):
     """Given a list of keys, returns a list of those
     resembling graphs.
     If passed a previous_manifest, will ignore the keys

--- a/utils/make_kg_manifest.py
+++ b/utils/make_kg_manifest.py
@@ -18,7 +18,6 @@ import botocore.exceptions
 import botocore.errorfactory
 import click
 import requests
-from torch import maximum
 import yaml
 import tarfile
 import sys
@@ -91,7 +90,7 @@ logger.addHandler(consolehandler)
                         Most helpful when building manifest from scratch.
                         If not specified, all objects on the remote
                         will be considered.""")
-def run(bucket: str, outpath: str):
+def run(bucket: str, outpath: str, maximum = None):
 
     # Download any existing manifest from the bucket.
     # We read it first to retain all existing records and update if needed.
@@ -381,7 +380,7 @@ def validate_projects(bucket: str, keys: list, graph_file_keys: dict) -> None:
         
     return project_contents
 
-def get_graph_file_keys(keys: list, previous_manifest = []):
+def get_graph_file_keys(keys: list, previous_manifest = [], maximum = None):
     """Given a list of keys, returns a list of those
     resembling graphs.
     If passed a previous_manifest, will ignore the keys


### PR DESCRIPTION
The `--maximum` option sets the total count of files to try to parse in one run.
This is necessary to build the initial full KG-Hub manifest, rather than indexing, loading, and validating hundreds of graphs in one go.